### PR TITLE
Fix NFT card images not loading in My Items

### DIFF
--- a/EluvioWalletTVOS/EluvioWalletTVOS/Views/NFTView.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/Views/NFTView.swift
@@ -129,7 +129,7 @@ struct NFTView: View {
           }
           .padding(.bottom)
           if image.hasPrefix("http") {
-            ScaledWebImage(url: propertyLogo, height: 420)
+            ScaledWebImage(url: image, height: 420)
               .resizable()
               .indicator(.activity)  // Activity Indicator
               .transition(.fade(duration: 0.5))


### PR DESCRIPTION
## Summary
- Fixed `ScaledWebImage` in `NFTView` passing `propertyLogo` instead of `image`, causing NFT card images to not load

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)