### PR TITLE
Fix memory leaks in video player

### DIFF
--- a/EluvioWalletTVOS/EluvioWalletTVOS/ContentView.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/ContentView.swift
@@ -273,10 +273,10 @@ struct ContentView: View {
 
         self.viewStateCancellable = viewState.$op
           .receive(on: DispatchQueue.main)  //Delays the sink closure to get called after didSet
-          .sink { val in
-            debugPrint("viewState changed.", viewState.op)
+          .sink { [weak viewState] val in
+            debugPrint("viewState changed.", viewState?.op)
             debugPrint("showNFT ", showNft)
-            if viewState.op == .none || AccountStore.shared.isLoggedOut {
+            if viewState?.op == .none || AccountStore.shared.isLoggedOut {
               self.showActivity = false
               return
             }

--- a/EluvioWalletTVOS/EluvioWalletTVOS/EluvioAPI/Stores/FabricConfigStore.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/EluvioAPI/Stores/FabricConfigStore.swift
@@ -1,12 +1,14 @@
 import Alamofire
 import Foundation
 import Observation
+import UIKit
 
 @Observable
 class FabricConfigStore {
   static let shared = FabricConfigStore()
 
   var config: FabricConfiguration
+  private var refreshTask: Task<Void, Never>?
 
   var apiBaseUrl: String {
     config.getAuthServices().first?.ensuringSuffix("/") ?? ""
@@ -31,16 +33,37 @@ class FabricConfigStore {
   private init() {
     let networkStore = NetworkStore.shared
     config = defaultConfig(for: networkStore.selectedNetwork)
-    Task {
+    startRefreshLoop(networkStore)
+
+    NotificationCenter.default.addObserver(
+      forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main
+    ) { [weak self] _ in
+      self?.startRefreshLoop(networkStore)
+    }
+    NotificationCenter.default.addObserver(
+      forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: .main
+    ) { [weak self] _ in
+      self?.stopRefreshLoop()
+    }
+  }
+
+  private func startRefreshLoop(_ networkStore: NetworkStore) {
+    guard refreshTask == nil else { return }
+    refreshTask = Task {
       repeat {
         do {
           await refreshConfig(for: networkStore.selectedNetwork)
-          try await Task.sleep(for: .minutes(3))  // This throws if task is cancelled
+          try await Task.sleep(for: .minutes(3))
         } catch {
           break
         }
       } while !Task.isCancelled
     }
+  }
+
+  private func stopRefreshLoop() {
+    refreshTask?.cancel()
+    refreshTask = nil
   }
 
   func refreshConfig(for network: AppMode) async {

--- a/EluvioWalletTVOS/EluvioWalletTVOS/SharedViews/LoopingPlayer.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/SharedViews/LoopingPlayer.swift
@@ -51,6 +51,10 @@ struct LoopingVideoPlayer<VideoOverlay: View>: View {
       }
     }
 
+    deinit {
+      NotificationCenter.default.removeObserver(self)
+    }
+
     @objc
     func rewindVideo(notification _: Notification) {
       player.seek(to: .zero)

--- a/EluvioWalletTVOS/EluvioWalletTVOS/SharedViews/PlayerView.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/SharedViews/PlayerView.swift
@@ -14,19 +14,22 @@ import SwiftUI
 class PlayerFinishedObserver: ObservableObject {
   @Published
   var publisher = PassthroughSubject<Void, Never>()
+  private var cancellable: AnyCancellable?
 
   init(player: AVPlayer? = nil) {
     if let player = player {
       let item = player.currentItem
 
-      var cancellable: AnyCancellable?
       cancellable = NotificationCenter.default.publisher(
         for: .AVPlayerItemDidPlayToEndTime, object: item
       ).sink { [weak self] _ in
         self?.publisher.send()
-        cancellable?.cancel()
       }
     }
+  }
+
+  deinit {
+    cancellable?.cancel()
   }
 }
 
@@ -65,6 +68,8 @@ struct PlayerView: View {
   var backLink: String = ""
   var backLinkIcon: String = ""
   @State var audioLoaded = false
+  @State private var progressObserverToken: Any?
+  @State private var errorLogObserver: NSObjectProtocol?
 
   enum Field: Hashable {
     case startFromBeginningField
@@ -257,7 +262,7 @@ struct PlayerView: View {
           debugPrint("MUX initialized.")
         }
 
-        player.addProgressObserver { progress in
+        progressObserverToken = player.addProgressObserver { progress in
           currentTimeS = player.currentItem?.currentTime().seconds ?? -1.0
 
           if currentTimeS == -1.0 {
@@ -294,9 +299,9 @@ struct PlayerView: View {
           }
         }
 
-        NotificationCenter.default.addObserver(
+        errorLogObserver = NotificationCenter.default.addObserver(
           forName: .AVPlayerItemNewErrorLogEntry, object: player.currentItem, queue: .main
-        ) { [self] _ in
+        ) { _ in
           print(player.currentItem?.errorLog()?.events.last?.errorComment)
         }
 
@@ -324,6 +329,16 @@ struct PlayerView: View {
     }
     .onWillDisappear {
       print("PlayerView onDisappear")
+      // Clean up progress observer
+      if let token = progressObserverToken {
+        player.removeTimeObserver(token)
+        progressObserverToken = nil
+      }
+      // Clean up error log observer
+      if let observer = errorLogObserver {
+        NotificationCenter.default.removeObserver(observer)
+        errorLogObserver = nil
+      }
       if useMultiview {
         multiviewModel.player?.pause()
         Task {
@@ -391,6 +406,7 @@ struct PlayerView2: View {
   @Binding var finished: Bool
 
   @State var playerItem: AVPlayerItem?
+  @State private var progressObserverToken: Any?
   @Binding var currentTimeMS: Int64
   @Binding var durationMS: Int64
   @Binding var seekTimeMS: Int64
@@ -449,7 +465,7 @@ struct PlayerView2: View {
       self.finishedObserver = PlayerFinishedObserver(player: player)
       debugPrint("PlayerView onAppear finsihed.")
 
-      player.addProgressObserver(intervalSeconds: 0.1) { _ in
+      progressObserverToken = player.addProgressObserver(intervalSeconds: 0.1) { _ in
         // debugPrint("Player progress: ", progress)
         // debugPrint("Player duration seconds: ", player.currentItem?.duration.seconds)
         // debugPrint("Player currentTime seconds: ", player.currentItem?.currentTime().seconds)
@@ -474,7 +490,12 @@ struct PlayerView2: View {
       }
     }
     .onDisappear {
+      if let token = progressObserverToken {
+        player.removeTimeObserver(token)
+        progressObserverToken = nil
+      }
       player.pause()
+      player.replaceCurrentItem(with: nil)
     }
   }
 

--- a/EluvioWalletTVOS/EluvioWalletTVOS/SharedViews/VideoPlayerView.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/SharedViews/VideoPlayerView.swift
@@ -125,6 +125,8 @@ class VideoPlayerViewModel: ObservableObject {
   var seekTimeS: Double = 0
   var currentTimeS: Double = -1
   private var errorLogObserver: NSObjectProtocol?
+  private var progressObserverToken: Any?
+
   var hasSeeked: Bool {
     return currentTimeS > seekTimeS
   }
@@ -139,6 +141,11 @@ class VideoPlayerViewModel: ObservableObject {
   }
 
   func clear() {
+    // Remove progress observer before releasing player
+    if let token = progressObserverToken, let player = player {
+      player.removeTimeObserver(token)
+    }
+    progressObserverToken = nil
     if let observer = errorLogObserver {
       NotificationCenter.default.removeObserver(observer)
       errorLogObserver = nil
@@ -241,7 +248,12 @@ class VideoPlayerViewModel: ObservableObject {
         return
       }
 
-      player?.addProgressObserver { progress in
+      // Remove previous progress observer before adding a new one
+      if let token = progressObserverToken, let oldPlayer = player {
+        oldPlayer.removeTimeObserver(token)
+      }
+      progressObserverToken = player?.addProgressObserver { [weak self] progress in
+        guard let self = self else { return }
         self.currentTimeS = self.player?.currentItem?.currentTime().seconds ?? -1.0
 
         if self.currentTimeS == -1.0 {

--- a/EluvioWalletTVOS/EluvioWalletTVOS/Utils/AudioPlayer.swift
+++ b/EluvioWalletTVOS/EluvioWalletTVOS/Utils/AudioPlayer.swift
@@ -50,9 +50,13 @@ class AudioPlayer {
 
   static func pause() {
     audioPlayer?.pause()
+    timer?.invalidate()
+    timer = nil
   }
 
   static func stop() {
     audioPlayer?.stop()
+    timer?.invalidate()
+    timer = nil
   }
 }


### PR DESCRIPTION
## Summary
- Fix multiple memory leaks in the video player causing the app to slow down over extended playback sessions
- Store and properly remove AVPlayer periodic time observer tokens, NotificationCenter observers, and Combine cancellables on view teardown
- Invalidate AudioPlayer timer on stop/pause to prevent accumulation
- Pause FabricConfigStore background refresh loop when app enters background, resume on foreground
- Use `[weak self]` / `[weak viewState]` in closures to break retain cycles

## Verified
Used a custom `LeakTracker` to confirm leaks before and after:
- **Before**: `VideoPlayerViewModel` and `PlayerFinishedObserver` never deallocated; observer count climbed +2 per player visit
- **After**: All objects return to 0 alive between visits; observer count stable at 1 (the active LoopingPlayer on home screen)

## Test plan
- [ ] Play video, navigate back, repeat 5+ times — confirm no slowdown
- [ ] Verify multiview player cleans up correctly
- [ ] Verify looping background video still loops
- [ ] Background the app, confirm no network polling; foreground and confirm it resumes
- [ ] Audio player: play, pause, play again — confirm no timer accumulation

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)